### PR TITLE
Documentation updates & clarifications

### DIFF
--- a/apps/demo/src/app/app.component.ts
+++ b/apps/demo/src/app/app.component.ts
@@ -4,6 +4,10 @@ import { RouterModule } from '@angular/router';
 import { AutoAnimationPlugin, getTransitionSizes } from '@formkit/auto-animate';
 import { NgAutoAnimateDirective } from 'ng-auto-animate';
 
+/*
+ * This is a helper type only. The original example is in JavaScript, not TypeScript, so no type is exported.
+ * Actual values can be any CSS properties.
+ */
 type KeyframeProps = {
   transform: string;
   opacity?: number;
@@ -26,16 +30,16 @@ type KeyframeProps = {
       <button (click)="start = !start">Start</button>
 
       <article>
-        <header auto-animate> <!-- Global default settings -->
+        <header auto-animate> <!-- Global default settings: Affects the <a *ngIf> below -->
           <a *ngIf="start" href="https://github.com/ajitzero/ng-auto-animate/tree/main/libs/ng-auto-animate#readme">📝 View README (Slow transition, from global default settings)</a>
         </header>
         <div class="grid">
           <button (click)="show = !show">Toggle (Custom plugin)</button>
           <button (click)="shuffle()">Shuffle (Explicit, inline settings)</button>
         </div>
-        <footer [auto-animate]="bouncyPlugin"> <!-- Custom plugin -->
+        <footer [auto-animate]="bouncyPlugin"> <!-- Custom plugin: Affects the <div *ngIf> below, but not its children -->
           <h3>Footer content</h3>
-          <div *ngIf="show" [auto-animate]="{ duration: 250 }"> <!-- Explicit, inline setting -->
+          <div *ngIf="show" [auto-animate]="{ duration: 250 }"> <!-- Explicit, inline setting: Affects the <p *ngFor> below -->
             <p *ngFor="let paragraph of paragraphs">{{ paragraph }}</p>
           </div>
         </footer>
@@ -44,7 +48,6 @@ type KeyframeProps = {
   `,
 })
 export class AppComponent {
-  title = 'Demo';
   start = false;
   show = false;
 
@@ -57,13 +60,16 @@ export class AppComponent {
 
   shuffle() {
     if (this.show) {
-      this.paragraphs = this.paragraphs.sort(() => Math.random() - 0.5);
+      // Replace `Array.prototype.sort()` with `Array.prototype.toSorted()` when it's stable
+      this.paragraphs = [...this.paragraphs].sort(() => Math.random() - 0.5);
     }
   }
 
   /**
    * This example plugin is a modified version of the "bouncy" plugin
-   * showcased in the the library's documentation.
+   * showcased in the library's documentation.
+   *
+   * @see https://auto-animate.formkit.com/#plugins
    */
   bouncyPlugin: AutoAnimationPlugin = (el, action, oldCoords, newCoords) => {
     let keyframes: KeyframeProps[] = [];

--- a/libs/ng-auto-animate/README.md
+++ b/libs/ng-auto-animate/README.md
@@ -1,17 +1,17 @@
 # ng-auto-animate
 
-An Angular Directive to use FormKit's [`auto-animate`](https://auto-animate.formkit.com) library, within Angular projects.
+An Angular Directive to use FormKit's [`auto-animate`](https://auto-animate.formkit.com) library within Angular projects.
 
 ### Highlights:
 - ✅ Standalone Directive, for Angular v14 and above. Tested on Node 18.x, but should work on previous versions.
 - ✅ Custom `InjectionToken` for configuring global settings and plugins.
 
 ### Why a new wrapper library?
-A publishable library for Angular needs [`ng-packagr`](https://github.com/ng-packagr/ng-packagr) and Angular CLI for proper scaffolding and finalized formatting. Migrating the repository structure for `auto-animate` is a non-trivial ask, and would need an unbiased build system like [Nx](https://nx.dev) (which I am using here) or some other similar tool.
+A publishable library for Angular needs [`ng-packagr`](https://github.com/ng-packagr/ng-packagr) and Angular CLI for proper scaffolding and finalized formatting. Migrating the repository structure for `auto-animate` is a non-trivial task and would need an unbiased build system like [Nx](https://nx.dev) (which I am using here) or some other similar tool.
 
 [Justin Schroeder](https://github.com/justin-schroeder), the creator of [`auto-animate`](https://auto-animate.formkit.com), has been supportive towards [contributions](https://github.com/formkit/auto-animate/pull/38) for Angular integration, but he [does not work with Angular](https://github.com/formkit/auto-animate/issues/72#issuecomment-1222732238) and is unable to work towards this actively. I, too, would not be able to do much in his shoes, especially when it requires replacing all build actions, scripts and the project structure, all to support a single framework.
 
-If there is a simpler solution, I would be willing to submit a PR with my changes here to the original project, especially the support fot global options/plugin via an `InjectionToken`.
+If there is a simpler solution, I would be willing to submit a PR with my changes here to the original project, especially the support for global options/plugin via an `InjectionToken`.
 
 ### Installation
 1. Install the peer dependency.
@@ -24,6 +24,12 @@ If there is a simpler solution, I would be willing to submit a PR with my change
     ```
 
 ### Usage
+#### Principle
+Add the directive to the parent tag, within which DOM elements are being shown or hidden dynamically.
+
+Adding the directive to the same tag which is being hidden will do nothing since it will look for changes in child nodes only.
+
+#### Variants
 1. Default usage:
     ```html
     <article auto-animate>

--- a/libs/ng-auto-animate/package.json
+++ b/libs/ng-auto-animate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-auto-animate",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Add motion to your apps with a single line of code. An Angular Directive to use FormKit's auto-animate library.",
   "repository": "https://github.com/ajitzero/ng-auto-animate.git",
   "homepage": "https://github.com/ajitzero/ng-auto-animate/tree/main/libs/ng-auto-animate#readme",

--- a/libs/ng-auto-animate/package.json
+++ b/libs/ng-auto-animate/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "Add motion to your apps with a single line of code. An Angular Directive to use FormKit's auto-animate library.",
   "repository": "https://github.com/ajitzero/ng-auto-animate.git",
+  "homepage": "https://github.com/ajitzero/ng-auto-animate/tree/main/libs/ng-auto-animate#readme",
   "author": "Ajit Panigrahi <hello@ajitpanigrahi.com>",
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
- Added "Principle" section to docs to explain how the elements for animation are detected.
- Addressed a few typos and grammar issues.
- Added the exact [homepage URL](https://github.com/ajitzero/ng-auto-animate/tree/main/libs/ng-auto-animate#readme) for NPM.
- Added clarification comments in the demo app.
- Bumped patch version.