### PR TITLE
fix: removed caret from peerDependencies' version range

### DIFF
--- a/libs/ng-auto-animate/package.json
+++ b/libs/ng-auto-animate/package.json
@@ -11,8 +11,8 @@
 		"tslib": "^2.3.0"
 	},
 	"peerDependencies": {
-		"@angular/common": "^17.1.0 - ^20.0.0",
-		"@angular/core": "^17.1.0 - ^20.0.0",
+		"@angular/common": "17.1.0 - 20.0.0",
+		"@angular/core": "17.1.0 - 20.0.0",
 		"@formkit/auto-animate": "^0.8.2"
 	},
 	"publishConfig": {


### PR DESCRIPTION
Pull request #42 updated peer dependencies' version range to include from v17 to v20, but according to [Version Range Examples](https://semver.npmjs.com/#syntax-examples), and testing using [npm SemVer Calculator], `^17.1.0 - ^20.0.0` is not a valid range expression and caret should be removed.

This PR removed caret from peerDependencies range to make range expression valid.